### PR TITLE
fix: provide terraform apply with GitHub token

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -11,6 +11,7 @@ env:
   TF_CLOUD_ORGANIZATION: "oliver-binns"
   TF_TOKEN_app_terraform_io: "${{ secrets.TF_API_TOKEN }}"
   TF_WORKSPACE: "prod"
+  TF_VAR_github_token: ${{ secrets.GH_TOKEN }}
 
 jobs:
   apply:


### PR DESCRIPTION
Ensure that Terraform can manage GitHub resources by providing it with a token